### PR TITLE
Remove a potential source of permission errors (improved)

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ or Digital Ocean: https://goo.gl/i3HFWr
 ```bash
 adduser <YOURUSERNAME>
 usermod -aG sudo <YOURUSERNAME>
-reboot -n
+su - <YOURUSERNAME>
 ```
 
 3) **Follow instructions to Create ZelNode Key using ZelCore Wallet**
@@ -47,9 +47,7 @@ Launch Full Node Wallet & go to **Tools | Open ZelNode Management | Create ZelNo
 
 Click ZelNode Key to copy to clipboard
 
-4) **Download scrypt & begin installation of ZelNode**
-
-**PLEASE BE SURE YOU ARE LOGGED IN AS YOUR USERNAME BEFORE RUNNING THIS SCRIPT (NOT SU)**
+4) **(Back on VPS) Download scrypt & begin installation of ZelNode**
 
 ```bash
 cd ~

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ or Digital Ocean: https://goo.gl/i3HFWr
 ```bash
 adduser <YOURUSERNAME>
 usermod -aG sudo <YOURUSERNAME>
-su - <YOURUSERNAME>
+exec su - <YOURUSERNAME>
 ```
 
 3) **Follow instructions to Create ZelNode Key using ZelCore Wallet**


### PR DESCRIPTION
`su - <USERNAME>` switches the user and adapts the users environment (thanks to the minus sign). If your concern is that a new shell is spawned instead of replacing the current one you could just do `exec su - <USERNAME>`. In that case, if you CTRL+D out of the session, you will NOT fall back to the previous shell but completely end your session. This is because `exec` replaces the execution environment. This has been adjusted in the commit (previous PR  was #1).

Many people who use that guide mess up their permissions and come to Discord to ask the same questions over and over again. I don't care if you merge or, but it will make it easier for team to help.
If you insist on keeping it this way, you NEED to highlight where exactly the new username and password need to be typed into PuTTy, it would be best to do that with a screenshot.

PS: I'm turbojeet on Discord.